### PR TITLE
fix(simulator): Ensure all nodes in a SupplyChain have a valid llc set

### DIFF
--- a/suppy/simulator.py
+++ b/suppy/simulator.py
@@ -271,6 +271,11 @@ class Simulator:
         else:
             start_period = start_or_end_period
 
+        # Check if all nodes have their llc set
+        for node in self.supply_chain.nodes.values():
+            if not isinstance(node.llc, int) or node.llc < 0:
+                raise ValueError(f"{node} has an invalid llc: {node.llc}")
+
         self._metrics = setup_metrics(
             filename=self.filename, stream=self.stream, max_bytes=self.max_bytes
         )

--- a/tests/suppy/test_simulator.py
+++ b/tests/suppy/test_simulator.py
@@ -137,6 +137,15 @@ def test_simulator_invalid_strategies():
         Simulator(sc, control_strategy=RSQ(sc), release_strategy=int)  # type: ignore
 
 
+def test_simulator_validate_llc():
+    """Test if an error is raised if any node does not have a valid llc set"""
+    sc = SupplyChain(nodes=[Node("A")])
+    sc.nodes["B"] = Node("B")
+    sim = Simulator(sc, MagicMock(), MagicMock())
+    with pytest.raises(ValueError, match=r"Node\(B\) has an invalid llc: -1"):
+        sim.run(1)
+
+
 def test_supply_chain_node_exists():
     sc = SupplyChain(nodes=[Node("A"), Node("B")])
 


### PR DESCRIPTION
nodes with an invalid llc (< 0 or non-integers) can crash the simulation or, in the worst case, silently be skipped.
This change will raise a ValueError when an invalid llc is found
