### PR TITLE
refactor(leadtime): Rewrite LeadTime as a dataclass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,42 +1,42 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
-    -   id: check-added-large-files
-    -   id: check-merge-conflict
-    -   id: mixed-line-ending
-        args: [--fix=lf]
-    -   id: no-commit-to-branch
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [ --fix=lf ]
+      - id: no-commit-to-branch
         name: Don't commit to the default branch
-        args: [--branch, main]
-    -   id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
+        args: [ --branch, main ]
+      - id: trailing-whitespace
+        args: [ --markdown-linebreak-ext=md ]
 
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 21.9b0
     hooks:
-    -   id: black
+      - id: black
 
--   repo: https://github.com/PyCQA/isort
+  - repo: https://github.com/PyCQA/isort
     rev: 5.9.3
     hooks:
-    -   id: isort
-        args: ["--profile", "black"]
+      - id: isort
+        args: [ "--profile", "black" ]
 
--   repo: local
+  - repo: local
     hooks:
-    -   id: mypy
+      - id: mypy
         name: mypy
-        types_or: [python, pyi]
-        stages: [commit]
+        types_or: [ python, pyi ]
+        stages: [ commit ]
         language: system
         entry: poetry run mypy --strict
 
--   repo: local
+  - repo: local
     hooks:
-    -   id: jupyter-nb-clear-output
+      - id: jupyter-nb-clear-output
         name: jupyter-nb-clear-output
-        types_or: [jupyter]
-        stages: [commit]
+        types_or: [ jupyter ]
+        stages: [ commit ]
         language: system
         entry: poetry run jupyter nbconvert --clear-output --ClearMetadataPreprocessor.enabled=True

--- a/tests/suppy/test_leadtime.py
+++ b/tests/suppy/test_leadtime.py
@@ -6,19 +6,36 @@ from suppy import leadtime
 def test_leadtime_no_default():
     """Test if an error is raised when no default is provided"""
     lt = leadtime.LeadTime()
-    with pytest.raises(KeyError):
-        lt[1]
+    with pytest.raises(ValueError):
+        lt.get_lead_time(1)
 
 
 def test_leadtime_default():
     """Test if we can set a default for leadtime"""
     lt = leadtime.LeadTime({3: 3}, default=5)
-    assert lt[1] == 5
-    assert lt[2] == 5
-    assert lt[3] == 3
+    assert lt.get_lead_time(1) == 5
+    assert lt.get_lead_time(2) == 5
+    assert lt.get_lead_time(3) == 3
 
 
 def test_leadtime_invalid():
     """Test if an error is raised if we provide invalid leadtime data"""
     with pytest.raises(TypeError):
         leadtime.LeadTime({3: "A"})  # type: ignore
+
+
+def test_leadtime_list():
+    """Test if we can use a list for lead-time"""
+    lt = leadtime.LeadTime([4, 2, 3, 1])
+    assert lt.get_lead_time(1) == 4
+    assert lt.get_lead_time(1) == 2
+    assert lt.get_lead_time(1) == 3
+    assert lt.get_lead_time(1) == 1
+
+
+def test_leadtime_dict():
+    """Test if we can use a list for lead-time"""
+    lt = leadtime.LeadTime({3: 3, 5: 2, 7: 1})
+    assert lt.get_lead_time(3) == 3
+    assert lt.get_lead_time(5) == 2
+    assert lt.get_lead_time(7) == 1

--- a/tests/suppy/test_leadtime.py
+++ b/tests/suppy/test_leadtime.py
@@ -29,7 +29,7 @@ def test_leadtime_list():
     lt = leadtime.LeadTime([4, 2, 3, 1])
     assert lt.get_lead_time(1) == 4
     assert lt.get_lead_time(1) == 2
-    assert lt.get_lead_time(1) == 3
+    assert lt.get_lead_time(1000) == 3
     assert lt.get_lead_time(1) == 1
 
 

--- a/tests/suppy/utils/test_parse.py
+++ b/tests/suppy/utils/test_parse.py
@@ -84,8 +84,8 @@ def test_supplychain_from_json(tmp_path):
 
     assert isinstance(node_a.lead_time, LeadTime)
     assert isinstance(node_b.lead_time, LeadTime)
-    assert node_a.lead_time == {1: 1, 2: 2, 3: 3, 4: 4}
-    assert node_b.lead_time == {1: 5, 2: 6}
+    assert node_a.lead_time == LeadTime({1: 1, 2: 2, 3: 3, 4: 4})
+    assert node_b.lead_time == LeadTime({1: 5, 2: 6}, default=42)
 
     assert node_a.backorders == 5
     assert node_b.backorders == 0
@@ -127,8 +127,8 @@ def test_supplychain_from_json(tmp_path):
 
     assert isinstance(node_a.lead_time, LeadTime)
     assert isinstance(node_b.lead_time, LeadTime)
-    assert node_a.lead_time == {1: 1, 2: 2, 3: 3, 4: 4}
-    assert node_b.lead_time == {1: 5, 2: 6}
+    assert node_a.lead_time == LeadTime({1: 1, 2: 2, 3: 3, 4: 4})
+    assert node_b.lead_time == LeadTime({1: 5, 2: 6}, default=42)
     with pytest.raises(ValueError):
         node_a.lead_time.get_lead_time(5)
     assert node_b.lead_time.get_lead_time(5) == 42
@@ -177,7 +177,7 @@ def test_supplychain_from_json_minimal(tmp_path):
     assert isinstance(node_a.sales, Sales)
     assert node_a.sales == {}
     assert isinstance(node_a.lead_time, LeadTime)
-    assert node_a.lead_time == {}
+    assert node_a.lead_time == LeadTime(default=42)
     assert node_a.backorders == 0
     assert isinstance(node_a.pipeline, Pipeline)
     assert node_a.pipeline == []
@@ -206,7 +206,7 @@ def test_supplychain_from_json_lead_time_default(tmp_path):
 
     node_a = result.nodes["A"]
 
-    assert node_a.lead_time == {}
+    assert node_a.lead_time == LeadTime(default=6)
     assert node_a.lead_time.get_lead_time(66) == 6
 
 


### PR DESCRIPTION
Storing LeadTime as a UserDict presented limitations when trying to build a LeadTime queue.
It also made the defaulting implementation less readable.

With this PR the LeadTime is represented as a dataclass with a `queue` attribute which takes a list or dict and a default.

closes #13 